### PR TITLE
Adjust auto complete mode and map load event

### DIFF
--- a/Forms/ZlizEQMapForm.Designer.cs
+++ b/Forms/ZlizEQMapForm.Designer.cs
@@ -1,4 +1,7 @@
-﻿namespace ZlizEQMap
+﻿using System;
+using System.Windows.Forms;
+
+namespace ZlizEQMap
 {
 	partial class ZlizEQMapForm
 	{
@@ -121,6 +124,9 @@
             this.comboZone.Size = new System.Drawing.Size(298, 21);
             this.comboZone.TabIndex = 2;
             this.comboZone.SelectedIndexChanged += new System.EventHandler(this.comboZone_SelectedIndexChanged);
+            this.comboZone.DropDownClosed += new EventHandler(this.comboZone_DropDownClosed);
+            this.comboZone.AutoCompleteSource = AutoCompleteSource.ListItems;
+            this.comboZone.AutoCompleteMode = AutoCompleteMode.SuggestAppend;
             // 
             // checkGroupByContinent
             // 

--- a/Forms/ZlizEQMapForm.Designer.cs
+++ b/Forms/ZlizEQMapForm.Designer.cs
@@ -123,7 +123,6 @@ namespace ZlizEQMap
             this.comboZone.Name = "comboZone";
             this.comboZone.Size = new System.Drawing.Size(298, 21);
             this.comboZone.TabIndex = 2;
-            this.comboZone.SelectedIndexChanged += new System.EventHandler(this.comboZone_SelectedIndexChanged);
             this.comboZone.DropDownClosed += new EventHandler(this.comboZone_DropDownClosed);
             this.comboZone.AutoCompleteSource = AutoCompleteSource.ListItems;
             this.comboZone.AutoCompleteMode = AutoCompleteMode.SuggestAppend;

--- a/Forms/ZlizEQMapForm.cs
+++ b/Forms/ZlizEQMapForm.cs
@@ -514,15 +514,10 @@ namespace ZlizEQMap
 				PopulateZoneComboBox();
 		}
 
-		private void comboZone_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			
-		}
-
 		private void comboZone_DropDownClosed(object sender, EventArgs e)
 		{
 			if (!comboZone.SelectedItem.ToString().StartsWith("-") && initialLoadCompleted)
-				SwitchZone(comboZone.SelectedItem.ToString(), 1);	
+				SwitchZone(comboZone.SelectedItem.ToString(), 1);
 		}
 
 		private void btnAutosize_Click(object sender, EventArgs e)

--- a/Forms/ZlizEQMapForm.cs
+++ b/Forms/ZlizEQMapForm.cs
@@ -516,8 +516,13 @@ namespace ZlizEQMap
 
 		private void comboZone_SelectedIndexChanged(object sender, EventArgs e)
 		{
+			
+		}
+
+		private void comboZone_DropDownClosed(object sender, EventArgs e)
+		{
 			if (!comboZone.SelectedItem.ToString().StartsWith("-") && initialLoadCompleted)
-				SwitchZone(comboZone.SelectedItem.ToString(), 1);
+				SwitchZone(comboZone.SelectedItem.ToString(), 1);	
 		}
 
 		private void btnAutosize_Click(object sender, EventArgs e)
@@ -763,7 +768,7 @@ namespace ZlizEQMap
             watcher.Filter = assembledLogNamefilter;
             forceLogReselection = true;
         }
-    }
+	}
 
     public class MapPoint
 	{


### PR DESCRIPTION
Adjusts the code so the map doesn't load until the drop down is closed (which saves from constant re-rendering when trying to "search" for a zone in the drop down or cycling through events).

Also adjusts the search mode to use prepend search. 